### PR TITLE
fix(recyclarr): prefer smaller 720p-1080p releases

### DIFF
--- a/apps/talos/arrs/recyclarr/recyclarr.yml
+++ b/apps/talos/arrs/recyclarr/recyclarr.yml
@@ -11,11 +11,47 @@ sonarr:
 
     include:
       - template: sonarr-quality-definition-series
-      - template: sonarr-v4-quality-profile-web-1080p
+      # 720p + 1080p (WEB / Bluray / HDTV). Profile is still named "WEB-1080p".
+      - template: sonarr-v4-quality-profile-web-1080p-alternative
 
+    # Sizes are MB per minute of runtime, so per-episode totals scale with
+    # episode length. At 45 min: preferred ~0.8 GB, max ~2.0 GB; at 60 min:
+    # preferred ~1.1 GB, max ~2.7 GB. min is a permissive floor, not a target.
     quality_definition:
-      type: movie
-      preferred_ratio: 0.075
+      type: series
+      qualities:
+        - name: WEBDL-1080p
+          min: 3
+          preferred: 18
+          max: 45
+        - name: WEBRip-1080p
+          min: 3
+          preferred: 18
+          max: 45
+        - name: HDTV-1080p
+          min: 3
+          preferred: 18
+          max: 45
+        - name: Bluray-1080p
+          min: 3
+          preferred: 18
+          max: 45
+        - name: WEBDL-720p
+          min: 2
+          preferred: 12
+          max: 35
+        - name: WEBRip-720p
+          min: 2
+          preferred: 12
+          max: 35
+        - name: HDTV-720p
+          min: 2
+          preferred: 12
+          max: 35
+        - name: Bluray-720p
+          min: 2
+          preferred: 12
+          max: 35
 
     custom_formats:
       # Optional
@@ -25,17 +61,6 @@ sonarr:
           - e1a997ddb54e3ecbfe06341ad323c458 # Obfuscated
           - 06d66ab109d4d2eddb2794d21526d140 # Retags
           - 1b3994c551cbb92a2c781af061f4ab44 # Scene
-        assign_scores_to:
-          - name: WEB-1080p
-
-      - trash_ids:
-          # Uncomment the next six lines to allow x265 HD releases with HDR/DV
-          - 47435ece6b99a0b477caf360e79ba0bb # x265 (HD)
-        assign_scores_to:
-          - name: WEB-1080p
-            score: 0
-      - trash_ids:
-          - 9b64dff695c2115facf1b6ea59c9bd07 # x265 (no HDR/DV)
         assign_scores_to:
           - name: WEB-1080p
 
@@ -50,27 +75,34 @@ radarr:
     include:
       # Comment out any of the following includes to disable them
       - template: radarr-quality-definition-movie
-      - template: radarr-quality-profile-remux-web-1080p
-      - template: radarr-custom-formats-remux-web-1080p
+      # Bluray-1080p + WEB 1080p + Bluray-720p. No Remux (Remux = 30-60 GB).
+      - template: radarr-quality-profile-hd-bluray-web
+      - template: radarr-custom-formats-hd-bluray-web
 
+    # Sizes are MB per minute of runtime, so totals scale with film length.
+    # At 115 min: preferred ~1.5 GB, max ~3.45 GB; at 90 min: preferred ~1.2 GB,
+    # max ~2.7 GB. min is a permissive floor so good 720p files aren't rejected.
     quality_definition:
       type: movie
-      preferred_ratio: 0.075
+      qualities:
+        - name: Bluray-1080p
+          min: 3
+          preferred: 13
+          max: 30
+        - name: WEBDL-1080p
+          min: 3
+          preferred: 13
+          max: 30
+        - name: WEBRip-1080p
+          min: 3
+          preferred: 13
+          max: 30
+        - name: Bluray-720p
+          min: 2
+          preferred: 10
+          max: 25
 
     custom_formats:
-      - trash_ids:
-          # - 0f12c086e289cf966fa5948eac571f44 # Hybrid
-          # - 570bc9ebecd92723d2d21500f4be314c # Remaster
-          # - eca37840c13c6ef2dd0262b141a5482f # 4K Remaster
-          # - e0c07d59beb37348e975a930d5e50319 # Criterion Collection
-          # - 9d27d9d2181838f76dee150882bdc58c # Masters of Cinema
-          # - db9b4c4b53d312a3ca5f1378f6440fc9 # Vinegar Syndrome
-          # - 957d0f44b592285f26449575e8b1167e # Special Edition
-          # - eecf3a857724171f968a66cb5719e152 # IMAX
-          # - 9f6cbff8cfe4ebbc1bde14c7b7bec0de # IMAX Enhanced
-        assign_scores_to:
-          - name: Remux + WEB 1080p
-
       # Optional
       - trash_ids:
           - b6832f586342ef70d9c128d40c07b872 # Bad Dual Groups
@@ -80,17 +112,12 @@ radarr:
           - 5c44f52a8714fdd79bb4d98e2673be1f # Retags
           - f537cf427b64c38c8e36298f657e4828 # Scene
         assign_scores_to:
-          - name: Remux + WEB 1080p
+          - name: HD Bluray + WEB
 
+      # Allow x265 (HD): the hd-bluray-web template scores it negative, which
+      # blocks it. Override to 0 so the smaller HEVC files are accepted.
       - trash_ids:
-          # Uncomment the next six lines to allow x265 HD releases with HDR/DV
           - dc98083864ea246d05a42df0d05f81cc # x265 (HD)
-
         assign_scores_to:
-          - name: Remux + WEB 1080p
+          - name: HD Bluray + WEB
             score: 0
-
-      - trash_ids:
-          - 839bea857ed2c0a8e084f3cbdbd65ecb # x265 (no HDR/DV)
-        assign_scores_to:
-          - name: Remux + WEB 1080p


### PR DESCRIPTION
## Motivation

The current recyclarr config prefers very large files. Radarr uses a Remux profile (30-60 GB per movie) and neither Sonarr nor Radarr caps file size, so the library skews far larger than wanted. Goal: 720p-1080p, ~700 MB-2 GB preferred, ~3-4 GB max.

## Changes

- **Radarr**: swap the `Remux + WEB 1080p` profile for `HD Bluray + WEB` (Bluray-1080p, WEB 1080p, Bluray-720p) and its matching custom-format template — no more remux.
- **Size caps**: quality definitions now set explicit min/preferred/max in MB per minute of runtime. Movies land ~1.5 GB preferred, ~3.5 GB max at typical runtime; episodes scale smaller.
- **Sonarr**: move to the 720p/1080p alternative profile so 720p is allowed, and fix the quality-definition type (`movie` -> `series`).
- **x265**: allow HEVC for smaller files at equal quality (override the template's negative score to 0 in Radarr; Sonarr already permits it).

Recyclarr only updates the policy — existing oversized files are not re-downloaded automatically.