### PR TITLE
ci(recyclarr): bump to 7.5.2 and enable Flux image auto-updates

### DIFF
--- a/apps/base/arrs/recyclarr-radarr.yaml
+++ b/apps/base/arrs/recyclarr-radarr.yaml
@@ -15,7 +15,7 @@ spec:
           restartPolicy: OnFailure
           containers:
             - name: recyclarr
-              image: ghcr.io/recyclarr/recyclarr:7.4.1
+              image: ghcr.io/recyclarr/recyclarr:7.5.2 # {"$imagepolicy": "flux-system:recyclarr"}
               imagePullPolicy: Always
               envFrom:
                 - configMapRef:

--- a/apps/base/arrs/recyclarr-sonarr.yaml
+++ b/apps/base/arrs/recyclarr-sonarr.yaml
@@ -13,7 +13,7 @@ spec:
           restartPolicy: OnFailure
           containers:
             - name: recyclarr
-              image: ghcr.io/recyclarr/recyclarr:7.4.1
+              image: ghcr.io/recyclarr/recyclarr:7.5.2 # {"$imagepolicy": "flux-system:recyclarr"}
               imagePullPolicy: Always
               envFrom:
                 - configMapRef:

--- a/apps/talos/arrs/recyclarr/recyclarr.yml
+++ b/apps/talos/arrs/recyclarr/recyclarr.yml
@@ -106,7 +106,6 @@ radarr:
       # Optional
       - trash_ids:
           - b6832f586342ef70d9c128d40c07b872 # Bad Dual Groups
-          - 90cedc1fea7ea5d11298bebd3d1d3223 # EVO (no WEBDL)
           - ae9b7c9ebde1f3bd336a8cbd1ec4c5e5 # No-RlsGroup
           - 7357cf5161efbf8c4d5d0c30b4815ee2 # Obfuscated
           - 5c44f52a8714fdd79bb4d98e2673be1f # Retags

--- a/apps/talos/recyclarr-image-policy.yaml
+++ b/apps/talos/recyclarr-image-policy.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: image.toolkit.fluxcd.io/v1beta2
+kind: ImagePolicy
+metadata:
+  name: recyclarr
+  namespace: flux-system
+spec:
+  imageRepositoryRef:
+    name: recyclarr
+  policy:
+    semver:
+      # Stay on 7.x. v8 removed `replace_existing_custom_formats`, which this
+      # cache-less CronJob relies on to re-adopt its custom formats each run.
+      range: '>=7.5.2 <8.0.0'

--- a/apps/talos/recyclarr-image-repository.yaml
+++ b/apps/talos/recyclarr-image-repository.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: image.toolkit.fluxcd.io/v1beta2
+kind: ImageRepository
+metadata:
+  name: recyclarr
+  namespace: flux-system
+spec:
+  image: ghcr.io/recyclarr/recyclarr
+  interval: 2h0m0s


### PR DESCRIPTION
## Motivation

PR #11 added per-quality size caps (the `qualities:` block) to the recyclarr config, but the pinned image `7.4.1` doesn't support that field — the sync CronJobs error out (`Property 'qualities' not found`) and skip the config. `qualities` was added in recyclarr 7.5.0.

## Changes

- Bump both recyclarr CronJobs to `7.5.2` (latest 7.x). Verified with a `--preview` run: the config now parses and applies the intended profiles, scores, and size caps.
- Add a Flux `ImageRepository` + `ImagePolicy` for recyclarr and the `$imagepolicy` marker on both CronJob images, matching the existing per-app automation (homepage, radarr, sonarr, …). The policy is pinned to `>=7.5.2 <8.0.0`: v8 removes `replace_existing_custom_formats`, which this cache-less CronJob relies on to re-adopt its custom formats on every run.
- Drop a stale custom-format trash_id (`90cedc1f` / EVO) that no longer exists in the TRaSH guide and was logged as a skipped warning.